### PR TITLE
Set `.DisplayName` in `tfbridge.ProviderInfo`

### DIFF
--- a/provider/cmd/pulumi-resource-consul/schema.json
+++ b/provider/cmd/pulumi-resource-consul/schema.json
@@ -1,5 +1,6 @@
 {
     "name": "consul",
+    "displayName": "Consul",
     "description": "A Pulumi package for creating and managing consul resources.",
     "keywords": [
         "pulumi",

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -45,6 +45,7 @@ func Provider() tfbridge.ProviderInfo {
 	prov := tfbridge.ProviderInfo{
 		P:           p,
 		Name:        "consul",
+		DisplayName: "Consul",
 		Description: "A Pulumi package for creating and managing consul resources.",
 		Keywords:    []string{"pulumi", "consul"},
 		License:     "Apache-2.0",


### PR DESCRIPTION
This PR is part of pulumi/registry#4672. The display name used was taken from `github.com/pulumi/registry/tools/resourcedocsgen/pkg/lookup.go`.